### PR TITLE
Prep next batch in the background

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 project(CudAD VERSION 1.0 LANGUAGES CUDA CXX)
 
 find_package(CUDA)
+find_package(Threads)
 set(CMAKE_CUDA_STANDARD 17)
 
 file(GLOB_RECURSE SRCS src/*.cu src/*.cpp src/*.h)
@@ -27,3 +28,4 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -dlto")
 
 target_link_libraries(CudAD ${CUDA_LIBRARIES})
 target_link_libraries(CudAD ${CUDA_CUBLAS_LIBRARIES})
+target_link_libraries(CudAD ${CMAKE_THREAD_LIBS_INIT})

--- a/src/dataset/batchloader.h
+++ b/src/dataset/batchloader.h
@@ -15,14 +15,18 @@
 #include <fstream>
 #include <random>
 #include <utility>
+#include <thread>
 
 struct BatchLoader {
-
     int                      batch_size;
-    int                      batches;
-    DataSet                  batch;
-    DataSet*                 data;
-    DataSet*                 data_buffer;
+    int                      batches_per_load;
+    volatile bool            next_batch_loaded;
+    // The dataset being actively read from
+    DataSet                  active_batch;
+    // The next batch to be read from
+    DataSet                  background_batch;
+
+    DataSet*                 load_buffer;
 
     // track which part of the buffer we look at
     int                      current_batch_index = 0;
@@ -33,20 +37,22 @@ struct BatchLoader {
     int                      positions_left_in_file = 0;
     int                      current_file_index     = 0;
 
-    BatchLoader(std::vector<std::string> p_files, int batch_size, int batches)
-        : batch_size(batch_size), batches(batches) {
-        data                   = new DataSet {};
-        data_buffer            = new DataSet {};
-        batch       .positions.resize(static_cast<uint64_t>(batch_size));
-        data       ->positions.resize(static_cast<uint64_t>(capacity()));
-        data_buffer->positions.resize(static_cast<uint64_t>(capacity()));
-        batch       .header.position_count = batch_size;
-        data       ->header.position_count = capacity();
-        data_buffer->header.position_count = capacity();
+    BatchLoader(std::vector<std::string> p_files, int batch_size, int batches_per_load)
+        : batch_size(batch_size), batches_per_load(batches_per_load) {
+        load_buffer            = new DataSet {};
+        load_buffer       ->positions.resize(static_cast<uint64_t>(capacity()));
+        load_buffer       ->header.position_count = capacity();
+
+        active_batch       .positions.resize(static_cast<uint64_t>(batch_size));
+        active_batch       .header.position_count = batch_size;
+        
+        background_batch   .positions.resize(static_cast<uint64_t>(batch_size));
+        background_batch   .header.position_count = batch_size;
 
         files                  = std::move(p_files);
         current_file_index     = -1;
         positions_left_in_file = 0;
+        next_batch_loaded      = false;
 
         files.erase(
             std::remove_if(
@@ -55,115 +61,94 @@ struct BatchLoader {
                 [](const std::string& s){return !isReadable<BINARY>(s);}),
             files.end());
 
-        if(files.size() == 0){
+        if (files.size() == 0) {
             logging::write("Cannot create BatchLoader with no valid files. EXITING");
             exit(-1);
         }
 
         fillBuffer();
-        std::swap(data_buffer, data);
-        fillBuffer();
+        std::thread t1(&BatchLoader::backgroundBatchLoading, this);
+        t1.detach();
     }
 
     virtual ~BatchLoader() {
-        delete data;
-        delete data_buffer;
+        delete load_buffer;
     }
 
-    int  capacity() const { return batch_size * batches; }
+    int capacity() const { return batch_size * batches_per_load; }
 
     void openNextFile() {
+        if (file.is_open()) file.close();
 
-        if (file.is_open()) {
-            file.close();
-        }
         while (!file.is_open()) {
-            current_file_index += 1;
-            current_file_index %= files.size();
+            current_file_index = (current_file_index + 1) % files.size();
+            
             file = std::ifstream {files[current_file_index], std::ios::binary};
+
             if (!file.is_open()) {
                 logging::write("Could not open file: " + files[current_file_index]);
                 file.close();
             }
         }
 
+        // get the positions in file
         Header header {};
-        // read header
         file.read(reinterpret_cast<char*>(&header), sizeof(Header));
-
-        // store how many fens to read from this file
         positions_left_in_file = header.position_count;
-
-//        logging::write("Opened: "
-//                       + files[current_file_index]
-//                       + " and found "
-//                       + std::to_string(positions_left_in_file)
-//                       + " positions");
     }
 
     void fillBuffer() {
-
-        // if no positions left in current file, open next one (most likely for the very first batch)
-        if(positions_left_in_file == 0){
-            openNextFile();
-        }
-
-        // store how many fens we still need to fill in
         int fens_to_fill = capacity();
-        // compute the offset at which we are going to store the data
-        int offset       = 0;
-        // open files as long as we still need to fill fens
+        int read_offset       = 0;
+
         while (fens_to_fill > 0) {
+            if (positions_left_in_file == 0) openNextFile();
 
-//            std::cout << "left in file: " << positions_left_in_file << std::endl;
-
+            // read as many positions as possible from current file
             int filling             = std::min(fens_to_fill, positions_left_in_file);
             positions_left_in_file -= filling;
-            file.read(reinterpret_cast<char*>(&data_buffer->positions[offset]),
+
+            file.read(reinterpret_cast<char*>(&load_buffer->positions[read_offset]),
                       sizeof(Position) * filling);
 
-//            std::shuffle(data_buffer->positions.begin(), data_buffer->positions.end(), std::mt19937(std::random_device()()));
-
-//            std::cout << "read  " << file.gcount() << " bytes" << std::endl;
-//            std::cout << "tried " << sizeof(Position) * filling << " bytes" << std::endl;
-//            std::cout << positions_left_in_file << std::endl;
-
-            if(file.gcount() != sizeof(Position) * filling){
+            if(file.gcount() != sizeof(Position) * filling) {
                 logging::write("Some issue occured while reading file");
                 exit(-1);
             }
 
-            offset       += filling;
+            read_offset  += filling;
             fens_to_fill -= filling;
-
-            // open the next file if we will loop
-            if(fens_to_fill > 0)
-                openNextFile();
-        }
-        if(positions_left_in_file == 0){
-            openNextFile();
         }
     }
 
-    DataSet* next(){
+    void backgroundBatchLoading() {
+        while (true) {
+            // we've looped through our entire loading buffer
+            if (current_batch_index >= batches_per_load) {
+                fillBuffer();
+                current_batch_index = 0;
+            }
 
-        // swap data buffer with data
-        if(current_batch_index >= batches){
-            std::swap(data_buffer, data);
-            // fill the new buffer (potentially multithreading next?)
-            fillBuffer();
-            current_batch_index = 0;
+            // copy from load buffer into our background batch
+            auto start = load_buffer->positions.begin() + current_batch_index * batch_size;
+            auto end = start + batch_size;
+            background_batch.positions.assign(start, end);
+            
+            current_batch_index++;
+            
+            // mark batch as loaded and wait
+            next_batch_loaded = 1;
+            while (next_batch_loaded);
         }
+    }
 
-        // assign the data to the batch
-        batch.positions.assign(data->positions.begin() + current_batch_index * batch_size, data->positions.begin() + current_batch_index * batch_size + batch_size);
-        // copy the data to the batch
-//        std::memcpy(&batch.positions[0],
-//                    &data->positions[current_batch_index * batch_size],
-//                    sizeof(Position) * batch_size);
+    DataSet* next() {
+        // wait until loaded
+        while (!next_batch_loaded);
 
-        current_batch_index ++;
-        return &batch;
+        active_batch.positions.assign(background_batch.positions.begin(), background_batch.positions.end());
+        next_batch_loaded = false;
+        return &active_batch;
     }
 };
 


### PR DESCRIPTION
Created a method to busy loop filling the buffer, and copying data into a "background buffer".

Speed increased on my machine from ~2.5M pos/s to ~2.95M pos/s. 

Validated all looping across files works. Validated epoch loss is the same, data loaded in same order.