### PR TITLE
Fix SArray naming inconsistencies

### DIFF
--- a/src/data/DenseMatrix.h
+++ b/src/data/DenseMatrix.h
@@ -28,8 +28,8 @@ struct DenseMatrix : public Matrix, public SArray<float> {
 
     public:
     DenseMatrix(uint32_t m, uint32_t n) : Matrix(m, n), SArray(m * n), leading_dimension {m} {
-        SArray::malloc_gpu();
-        SArray::malloc_cpu();
+        SArray::mallocGpu();
+        SArray::mallocCpu();
     }
 
     float& get(int p_m, int p_n) {
@@ -46,8 +46,8 @@ struct DenseMatrix : public Matrix, public SArray<float> {
     friend std::ostream& operator<<(std::ostream& os, const DenseMatrix& data) {
 
         os << "size:       " << data.size() << "\n"
-           << "gpu_values: " << data.gpu_address() << "]\n"
-           << "cpu_values: " << data.cpu_address() << "]\n";
+           << "gpu_values: " << data.gpuAddress() << "]\n"
+           << "cpu_values: " << data.cpuAddress() << "]\n";
 
         if (data.n != 1) {
             os << std::fixed << std::setprecision(5);

--- a/src/data/SparseInput.h
+++ b/src/data/SparseInput.h
@@ -40,8 +40,8 @@ struct SparseInput : public Matrix {
     SparseInput(uint32_t m, uint32_t n, uint32_t max_entries_per_column)
         : Matrix(m, n), max_entries_per_column(max_entries_per_column) {
         column_indices = SArray<uint32_t> {n * (1 + max_entries_per_column)};
-        column_indices.malloc_gpu();
-        column_indices.malloc_cpu();
+        column_indices.mallocGpu();
+        column_indices.mallocCpu();
     }
 
     void set(int input_idx, int index) const {

--- a/src/layer/DenseLayer.h
+++ b/src/layer/DenseLayer.h
@@ -46,8 +46,8 @@ class DenseLayer : public LayerInterface {
         weights.values.randomiseGaussian(0.0f, (float) sqrt(2.0f / previous->getOutputSize()));
 
         // upload to gpu
-        weights.values.gpu_upload();
-        bias   .values.gpu_upload();
+        weights.values.gpuUpload();
+        bias   .values.gpuUpload();
     }
 
     DenseLayer(LayerInterface* previous, DenseLayer<O>* copy) : previous(previous){

--- a/src/loss/MLE.cu
+++ b/src/loss/MLE.cu
@@ -35,6 +35,6 @@ void MLE::apply(const SArray<float>& output,
 void           MLE::logOverview() { logging::write("MLE"); }
 SArray<float>& MLE::getLoss() { return loss; }
 MLE::MLE() {
-    loss.malloc_gpu();
-    loss.malloc_cpu();
+    loss.mallocGpu();
+    loss.mallocCpu();
 }

--- a/src/loss/MPE.cu
+++ b/src/loss/MPE.cu
@@ -39,6 +39,6 @@ SArray<float>& MPE::getLoss() { return loss; }
 MPE::MPE(float power, bool avg_gradients) {
     m_power         = power;
     m_avg_gradients = avg_gradients;
-    loss.malloc_gpu();
-    loss.malloc_cpu();
+    loss.mallocGpu();
+    loss.mallocCpu();
 }

--- a/src/loss/MSE.cu
+++ b/src/loss/MSE.cu
@@ -34,6 +34,6 @@ void MSE::apply(const SArray<float>& output,
 void           MSE::logOverview() { logging::write("MSE"); }
 SArray<float>& MSE::getLoss() { return loss; }
 MSE::MSE() {
-    loss.malloc_gpu();
-    loss.malloc_cpu();
+    loss.mallocGpu();
+    loss.mallocCpu();
 }

--- a/src/main.cu
+++ b/src/main.cu
@@ -87,11 +87,11 @@ int main() {
 //    DenseMatrix target{1,1};
 //    target(0,0) = 0.3;
 //    SArray<bool> target_mask{1};
-//    target_mask.malloc_cpu();
-//    target_mask.malloc_gpu();
+//    target_mask.mallocCpu();
+//    target_mask.mallocGpu();
 //    target_mask(0) = true;
-//    target_mask.gpu_upload();
-//    target.gpu_upload();
+//    target_mask.gpuUpload();
+//    target.gpuUpload();
 //
 //    finite_difference(network, target, target_mask);
 

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -53,8 +53,8 @@ class Network {
         }
     }
     void batch(DenseMatrix& target, SArray<bool>& target_mask) {
-        ASSERT(target.is_allocated<DEVICE>());
-        ASSERT(target_mask.is_allocated<DEVICE>());
+        ASSERT(target.isAllocated<DEVICE>());
+        ASSERT(target_mask.isAllocated<DEVICE>());
         ASSERT(loss_function);
         feed();
         loss_function->apply(getOutput().values, getOutput().gradients, target, target_mask, DEVICE);
@@ -79,7 +79,7 @@ class Network {
         for (LayerInterface* l : layers) {
             for (Tape* t : l->getTunableParameters()) {
                 fread(t->values.address<HOST>(), sizeof(float), t->values.size(), f);
-                t->values.gpu_upload();
+                t->values.gpuUpload();
             }
         }
         fclose(f);
@@ -98,7 +98,7 @@ class Network {
         fwrite(&count, sizeof(uint64_t), 1, f);
         for (LayerInterface* l : layers) {
             for (Tape* t : l->getTunableParameters()) {
-                t->values.gpu_download();
+                t->values.gpuDownload();
                 fwrite(t->values.address<HOST>(), sizeof(float), t->values.size(), f);
             }
         }
@@ -124,9 +124,9 @@ class Network {
     void uploadInputs(){
         for(LayerInterface* l:inputs){
             if(l->isSparse()){
-                l->sparse_data.column_indices.gpu_upload();
+                l->sparse_data.column_indices.gpuUpload();
             }else{
-                l->dense_data.values.gpu_upload();
+                l->dense_data.values.gpuUpload();
             }
         }
     }

--- a/src/numerical/finite_difference.h
+++ b/src/numerical/finite_difference.h
@@ -46,39 +46,39 @@ void finite_difference(Network& network, DenseMatrix& target, SArray<bool> &targ
                 auto bot_weight     = current_weight - margin;
 
                 t->values.get(wgt_idx) = top_weight;
-                t->values.gpu_upload();
+                t->values.gpuUpload();
                 // feed and download loss
                 network.batch(target, target_mask);
-                network.getLossFunction()->getLoss().gpu_download();
+                network.getLossFunction()->getLoss().gpuDownload();
                 auto top_loss = network.getLossFunction()->getLoss().get(0);
                 network.getLossFunction()->getLoss().get(0) = 0;
-                network.getLossFunction()->getLoss().gpu_upload();
+                network.getLossFunction()->getLoss().gpuUpload();
 
                 // clear gradients
                 adam.apply(network.getBatchSize());
 
                 t->values.get(wgt_idx) = bot_weight;
-                t->values.gpu_upload();
+                t->values.gpuUpload();
                 // feed and download loss
                 network.batch(target, target_mask);
-                network.getLossFunction()->getLoss().gpu_download();
+                network.getLossFunction()->getLoss().gpuDownload();
                 // clear gradients
                 adam.apply(network.getBatchSize());
 
                 auto bot_loss = network.getLossFunction()->getLoss().get(0);
                 network.getLossFunction()->getLoss().get(0) = 0;
-                network.getLossFunction()->getLoss().gpu_upload();
+                network.getLossFunction()->getLoss().gpuUpload();
 
                 t->values.get(wgt_idx) = current_weight;
-                t->values.gpu_upload();
+                t->values.gpuUpload();
                 // feed and download loss and gradients
                 network.batch(target, target_mask);
-                network.getLossFunction()->getLoss().gpu_download();
-                t->gradients.gpu_download();
+                network.getLossFunction()->getLoss().gpuDownload();
+                t->gradients.gpuDownload();
 
                 auto autodiff_gradient = t->gradients.get(wgt_idx);
                 network.getLossFunction()->getLoss().get(0) = 0;
-                network.getLossFunction()->getLoss().gpu_upload();
+                network.getLossFunction()->getLoss().gpuUpload();
 
                 // clear gradients
                 adam.apply(network.getBatchSize());

--- a/src/operations/adam/adam.h
+++ b/src/operations/adam/adam.h
@@ -65,18 +65,18 @@ inline void adam(SArray<float>& values,
         dim3 block(block_size);
         dim3 grid (std::ceil((float)values.size() / block_size));
         adam_kernel<<<grid, block>>>(
-            values          .gpu_address(),
-            gradients       .gpu_address(),
-            first_moment    .gpu_address(),
-            second_moment   .gpu_address(),
+            values          .gpuAddress(),
+            gradients       .gpuAddress(),
+            first_moment    .gpuAddress(),
+            second_moment   .gpuAddress(),
             values.size(),
             alpha, beta1, beta2, eps);
     }else{
         adam_host(
-            values          .cpu_address(),
-            gradients       .cpu_address(),
-            first_moment    .cpu_address(),
-            second_moment   .cpu_address(),
+            values          .cpuAddress(),
+            gradients       .cpuAddress(),
+            first_moment    .cpuAddress(),
+            second_moment   .cpuAddress(),
             values.size(),
             alpha, beta1, beta2, eps);
     }

--- a/src/operations/adam_w/adam_w.h
+++ b/src/operations/adam_w/adam_w.h
@@ -70,18 +70,18 @@ inline void adam_w(SArray<float>& values,
         dim3 block(block_size);
         dim3 grid (std::ceil((float)values.size / block_size));
         adam_w_kernel<<<grid, block>>>(
-            values          .gpu_address(),
-            gradients       .gpu_address(),
-            first_moment    .gpu_address(),
-            second_moment   .gpu_address(),
+            values          .gpuAddress(),
+            gradients       .gpuAddress(),
+            first_moment    .gpuAddress(),
+            second_moment   .gpuAddress(),
             values.size,
             step, lr, beta1, beta2, eps, warmup);
     } else {
         adam_w_host(
-            values          .cpu_address(),
-            gradients       .cpu_address(),
-            first_moment    .cpu_address(),
-            second_moment   .cpu_address(),
+            values          .cpuAddress(),
+            gradients       .cpuAddress(),
+            first_moment    .cpuAddress(),
+            second_moment   .cpuAddress(),
             values.size,
             step, lr, beta1, beta2, eps, warmup);
     }

--- a/src/operations/add/add.h
+++ b/src/operations/add/add.h
@@ -74,17 +74,17 @@ inline void add   ( const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
-        ASSERT(C.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
+        ASSERT(C.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)size / block_size));
         add_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
-            C.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
+            C.gpuAddress(),
             A.size(),
             B.size(),
             C.size(),
@@ -93,9 +93,9 @@ inline void add   ( const SArray<float> &A,
             beta);
     }else{
         add_host(
-            A.cpu_address(),
-            B.cpu_address(),
-            C.cpu_address(),
+            A.cpuAddress(),
+            B.cpuAddress(),
+            C.cpuAddress(),
             A.size(),
             B.size(),
             C.size(),

--- a/src/operations/add_mv/add_mv.h
+++ b/src/operations/add_mv/add_mv.h
@@ -66,9 +66,9 @@ inline void add_mv( const DenseMatrix &mat,
 
     if(mode == DEVICE){
 
-        ASSERT(mat.gpu_address());
-        ASSERT(vec.gpu_address());
-        ASSERT(res.gpu_address());
+        ASSERT(mat.gpuAddress());
+        ASSERT(vec.gpuAddress());
+        ASSERT(res.gpuAddress());
 
         constexpr int block_size_x = 16;
         constexpr int block_size_y = 16;
@@ -76,22 +76,22 @@ inline void add_mv( const DenseMatrix &mat,
         dim3 grid (std::ceil((float)mat.n / block_size_x),
                    std::ceil((float)mat.m / block_size_y));
         add_mv_kernel<<<grid, block>>>(
-            mat.gpu_address(),
-            vec.gpu_address(),
-            res.gpu_address(),
+            mat.gpuAddress(),
+            vec.gpuAddress(),
+            res.gpuAddress(),
             mat.m,
             mat.n,
             mat.leading_dimension,
             res.leading_dimension);
     }else{
-        ASSERT(mat.cpu_address());
-        ASSERT(vec.cpu_address());
-        ASSERT(res.cpu_address());
+        ASSERT(mat.cpuAddress());
+        ASSERT(vec.cpuAddress());
+        ASSERT(res.cpuAddress());
 
         add_mv_host(
-            mat.cpu_address(),
-            vec.cpu_address(),
-            res.cpu_address(),
+            mat.cpuAddress(),
+            vec.cpuAddress(),
+            res.cpuAddress(),
             mat.m,
             mat.n,
             mat.leading_dimension,

--- a/src/operations/add_mv_bp/add_mv_bp.h
+++ b/src/operations/add_mv_bp/add_mv_bp.h
@@ -64,9 +64,9 @@ inline void add_mv_bp( const DenseMatrix &mat_grd,
 
     if(mode == DEVICE){
 
-        ASSERT(mat_grd.gpu_address());
-        ASSERT(vec_grd.gpu_address());
-        ASSERT(res_grd.gpu_address());
+        ASSERT(mat_grd.gpuAddress());
+        ASSERT(vec_grd.gpuAddress());
+        ASSERT(res_grd.gpuAddress());
 
         constexpr int block_size_x = 16;
         constexpr int block_size_y = 16;
@@ -74,22 +74,22 @@ inline void add_mv_bp( const DenseMatrix &mat_grd,
         dim3 grid (std::ceil((float)mat_grd.n / block_size_x),
                    std::ceil((float)mat_grd.m / block_size_y));
         add_mv_bp_kernel<<<grid, block>>>(
-            mat_grd.gpu_address(),
-            vec_grd.gpu_address(),
-            res_grd.gpu_address(),
+            mat_grd.gpuAddress(),
+            vec_grd.gpuAddress(),
+            res_grd.gpuAddress(),
             mat_grd.m,
             mat_grd.n,
             mat_grd.leading_dimension,
             res_grd.leading_dimension);
     }else{
-        ASSERT(mat_grd.cpu_address());
-        ASSERT(vec_grd.cpu_address());
-        ASSERT(res_grd.cpu_address());
+        ASSERT(mat_grd.cpuAddress());
+        ASSERT(vec_grd.cpuAddress());
+        ASSERT(res_grd.cpuAddress());
 
         add_mv_bp_host(
-            mat_grd.cpu_address(),
-            vec_grd.cpu_address(),
-            res_grd.cpu_address(),
+            mat_grd.cpuAddress(),
+            vec_grd.cpuAddress(),
+            res_grd.cpuAddress(),
             mat_grd.m,
             mat_grd.n,
             mat_grd.leading_dimension,

--- a/src/operations/bucket/bucket.h
+++ b/src/operations/bucket/bucket.h
@@ -41,28 +41,28 @@ inline void bucket  ( const SArray<float> &inp,
 
     if(mode == DEVICE){
 
-        ASSERT(inp.gpu_address());
-        ASSERT(out.gpu_address());
+        ASSERT(inp.gpuAddress());
+        ASSERT(out.gpuAddress());
 
         constexpr int block_size_x = 1024;
         dim3 block(block_size_x);
         dim3 grid (std::ceil((float)inp.size() / block_size_x));
         bucket_kernel<<<grid, block>>>(
-            inp.gpu_address(),
-            out.gpu_address(),
+            inp.gpuAddress(),
+            out.gpuAddress(),
             max_lower_bucket,
             min_upper_bucket,
             bucket_size,
             inp.size());
     }else{
-//        ASSERT(mat_grd.cpu_address());
-//        ASSERT(vec_grd.cpu_address());
-//        ASSERT(res_grd.cpu_address());
+//        ASSERT(mat_grd.cpuAddress());
+//        ASSERT(vec_grd.cpuAddress());
+//        ASSERT(res_grd.cpuAddress());
 //
 //        add_mv_bp_host(
-//            mat_grd.cpu_address(),
-//            vec_grd.cpu_address(),
-//            res_grd.cpu_address(),
+//            mat_grd.cpuAddress(),
+//            vec_grd.cpuAddress(),
+//            res_grd.cpuAddress(),
 //            mat_grd.m,
 //            mat_grd.n,
 //            mat_grd.leading_dimension,

--- a/src/operations/bucket_bp/bucket_bp.h
+++ b/src/operations/bucket_bp/bucket_bp.h
@@ -43,30 +43,30 @@ inline void bucket_bp(const SArray<float> &inp,
 
     if(mode == DEVICE){
 
-        ASSERT(inp.gpu_address());
-        ASSERT(inp_grd.gpu_address());
-        ASSERT(out_grd.gpu_address());
+        ASSERT(inp.gpuAddress());
+        ASSERT(inp_grd.gpuAddress());
+        ASSERT(out_grd.gpuAddress());
 
         constexpr int block_size_x = 1024;
         dim3 block(block_size_x);
         dim3 grid (std::ceil((float)inp.size() / block_size_x));
         bucket_bp_kernel<<<grid, block>>>(
-            inp.gpu_address(),
-            inp_grd.gpu_address(),
-            out_grd.gpu_address(),
+            inp.gpuAddress(),
+            inp_grd.gpuAddress(),
+            out_grd.gpuAddress(),
             max_lower_bucket,
             min_upper_bucket,
             bucket_size,
             inp.size());
     }else{
-//        ASSERT(mat_grd.cpu_address());
-//        ASSERT(vec_grd.cpu_address());
-//        ASSERT(res_grd.cpu_address());
+//        ASSERT(mat_grd.cpuAddress());
+//        ASSERT(vec_grd.cpuAddress());
+//        ASSERT(res_grd.cpuAddress());
 //
 //        add_mv_bp_host(
-//            mat_grd.cpu_address(),
-//            vec_grd.cpu_address(),
-//            res_grd.cpu_address(),
+//            mat_grd.cpuAddress(),
+//            vec_grd.cpuAddress(),
+//            res_grd.cpuAddress(),
 //            mat_grd.m,
 //            mat_grd.n,
 //            mat_grd.leading_dimension,

--- a/src/operations/clamp/clamp.h
+++ b/src/operations/clamp/clamp.h
@@ -48,10 +48,10 @@ inline void clamp(SArray<float>& values,
         dim3 block(block_size);
         dim3 grid (std::ceil((float)values.size() / block_size));
         clamp_kernel<<<grid, block>>>(
-            values.gpu_address(),min,max,values.size());
+            values.gpuAddress(),min,max,values.size());
     }else{
         clamp_host(
-            values.cpu_address(),min,max,values.size());
+            values.cpuAddress(),min,max,values.size());
     }
 //    cudaDeviceSynchronize();
 }

--- a/src/operations/clipped_relu/clipped_relu.h
+++ b/src/operations/clipped_relu/clipped_relu.h
@@ -47,21 +47,21 @@ inline void clipped_relu   (const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         clipped_relu_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
             A.size(),
             max);
     }else{
         clipped_relu_host(
-            A.cpu_address(),
-            B.cpu_address(),
+            A.cpuAddress(),
+            B.cpuAddress(),
             A.size(),
             max);
     }

--- a/src/operations/clipped_relu_bp/clipped_relu_bp.h
+++ b/src/operations/clipped_relu_bp/clipped_relu_bp.h
@@ -52,25 +52,25 @@ inline void clipped_relu_bp (const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         clipped_relu_bp_kernel<<<grid, block>>>(
-            A    .gpu_address(),
-            A_grd.gpu_address(),
-            B    .gpu_address(),
-            B_grd.gpu_address(),
+            A    .gpuAddress(),
+            A_grd.gpuAddress(),
+            B    .gpuAddress(),
+            B_grd.gpuAddress(),
             A.size(),
             max);
     }else{
         clipped_relu_bp_host(
-            A    .cpu_address(),
-            A_grd.cpu_address(),
-            B    .cpu_address(),
-            B_grd.cpu_address(),
+            A    .cpuAddress(),
+            A_grd.cpuAddress(),
+            B    .cpuAddress(),
+            B_grd.cpuAddress(),
             A.size(),
             max);
     }

--- a/src/operations/merge/merge.h
+++ b/src/operations/merge/merge.h
@@ -47,9 +47,9 @@ void merge(const DenseMatrix &A,
         dim3 grid (std::ceil((float)C.n / block_size_x),
                    std::ceil((float)C.m / block_size_y));
         merge_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
-            C.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
+            C.gpuAddress(),
             A.m,
             B.m,
             C.n);

--- a/src/operations/merge_bp/merge_bp.h
+++ b/src/operations/merge_bp/merge_bp.h
@@ -47,9 +47,9 @@ void merge_bp(const DenseMatrix &A_grd,
         dim3 grid (std::ceil((float)C_grd.n / block_size_x),
                    std::ceil((float)C_grd.m / block_size_y));
         merge_bp_kernel<<<grid, block>>>(
-            A_grd.gpu_address(),
-            B_grd.gpu_address(),
-            C_grd.gpu_address(),
+            A_grd.gpuAddress(),
+            B_grd.gpuAddress(),
+            C_grd.gpuAddress(),
             A_grd.m,
             B_grd.m,
             C_grd.n);

--- a/src/operations/mle/mle.h
+++ b/src/operations/mle/mle.h
@@ -48,21 +48,21 @@ inline void mle (const SArray<float>& output,
 
     if(mode == DEVICE){
 
-        ASSERT(output.gpu_address());
-        ASSERT(output_gradient.gpu_address());
-        ASSERT(target.gpu_address());
-        ASSERT(mask.gpu_address());
-        ASSERT(loss.gpu_address());
+        ASSERT(output.gpuAddress());
+        ASSERT(output_gradient.gpuAddress());
+        ASSERT(target.gpuAddress());
+        ASSERT(mask.gpuAddress());
+        ASSERT(loss.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)output.size() / block_size));
         mle_kernel<<<grid, block>>>(
-            output          .gpu_address(),
-            output_gradient .gpu_address(),
-            target          .gpu_address(),
-            mask            .gpu_address(),
-            loss            .gpu_address(),
+            output          .gpuAddress(),
+            output_gradient .gpuAddress(),
+            target          .gpuAddress(),
+            mask            .gpuAddress(),
+            loss            .gpuAddress(),
             target          .size());
 
     }else{

--- a/src/operations/mm/mm_cublas.h
+++ b/src/operations/mm/mm_cublas.h
@@ -46,9 +46,9 @@ inline void mm_cublas(
     // clang-format off
     cublasSgemm(CUBLAS_HANDLE, trans_a, trans_b,
                 m, n, k, &alpha,
-                A.gpu_address(), lda,
-                B.gpu_address(), ldb, &beta,
-                C.gpu_address(), ldc);
+                A.gpuAddress(), lda,
+                B.gpuAddress(), ldb, &beta,
+                C.gpuAddress(), ldc);
     // clang-format on
 
     CUDA_ASSERT(cudaPeekAtLastError());

--- a/src/operations/mpe/mpe.h
+++ b/src/operations/mpe/mpe.h
@@ -47,22 +47,22 @@ inline void mpe (const SArray<float>& output,
 
     if(mode == DEVICE){
 
-        ASSERT(output.gpu_address());
-        ASSERT(output_gradient.gpu_address());
-        ASSERT(target.gpu_address());
-        ASSERT(mask.gpu_address());
-        ASSERT(loss.gpu_address());
+        ASSERT(output.gpuAddress());
+        ASSERT(output_gradient.gpuAddress());
+        ASSERT(target.gpuAddress());
+        ASSERT(mask.gpuAddress());
+        ASSERT(loss.gpuAddress());
 
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)output.size() / block_size));
         mpe_kernel<<<grid, block>>>(
-            output          .gpu_address(),
-            output_gradient .gpu_address(),
-            target          .gpu_address(),
-            mask            .gpu_address(),
-            loss            .gpu_address(),
+            output          .gpuAddress(),
+            output_gradient .gpuAddress(),
+            target          .gpuAddress(),
+            mask            .gpuAddress(),
+            loss            .gpuAddress(),
             power,
             output.size(),
             avg_grad ? output.size() : 1);

--- a/src/operations/mse/mse.h
+++ b/src/operations/mse/mse.h
@@ -43,22 +43,22 @@ inline void mse (const SArray<float>& output,
 
     if(mode == DEVICE){
 
-        ASSERT(output.gpu_address());
-        ASSERT(output_gradient.gpu_address());
-        ASSERT(target.gpu_address());
-        ASSERT(mask.gpu_address());
-        ASSERT(loss.gpu_address());
+        ASSERT(output.gpuAddress());
+        ASSERT(output_gradient.gpuAddress());
+        ASSERT(target.gpuAddress());
+        ASSERT(mask.gpuAddress());
+        ASSERT(loss.gpuAddress());
 
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)output.size() / block_size));
         mse_kernel<<<grid, block>>>(
-            output          .gpu_address(),
-            output_gradient .gpu_address(),
-            target          .gpu_address(),
-            mask            .gpu_address(),
-            loss            .gpu_address(),
+            output          .gpuAddress(),
+            output_gradient .gpuAddress(),
+            target          .gpuAddress(),
+            mask            .gpuAddress(),
+            loss            .gpuAddress(),
             output.size());
 
     }else{

--- a/src/operations/pairwise_multiply/pairwise_multiply.h
+++ b/src/operations/pairwise_multiply/pairwise_multiply.h
@@ -35,16 +35,16 @@ inline void pairwise_multiply (
                       SArray<float>& output){
     if(mode == DEVICE){
 
-        ASSERT(input.gpu_address());
-        ASSERT(output.gpu_address());
+        ASSERT(input.gpuAddress());
+        ASSERT(output.gpuAddress());
         ASSERT(input.size() == 2 * output.size());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)output.size() / block_size));
         pairwise_multiply_kernel<<<grid, block>>>(
-            input .gpu_address(),
-            output.gpu_address(),
+            input .gpuAddress(),
+            output.gpuAddress(),
             output.size());
     }else{
         ASSERT(false);

--- a/src/operations/pairwise_multiply_bp/pairwise_multiply_bp.h
+++ b/src/operations/pairwise_multiply_bp/pairwise_multiply_bp.h
@@ -37,9 +37,9 @@ inline void pairwise_multiply_bp (
                const SArray<float>& output_grd){
     if(mode == DEVICE){
 
-        ASSERT(input.gpu_address());
-        ASSERT(input_grd.gpu_address());
-        ASSERT(output_grd.gpu_address());
+        ASSERT(input.gpuAddress());
+        ASSERT(input_grd.gpuAddress());
+        ASSERT(output_grd.gpuAddress());
         ASSERT(input.size() == 2 * output_grd.size());
         ASSERT(input.size() == input_grd.size());
 
@@ -47,9 +47,9 @@ inline void pairwise_multiply_bp (
         dim3 block(block_size);
         dim3 grid (std::ceil((float)output_grd.size() / block_size));
         pairwise_multiply_bp_kernel<<<grid, block>>>(
-            input     .gpu_address(),
-            input_grd .gpu_address(),
-            output_grd.gpu_address(),
+            input     .gpuAddress(),
+            input_grd .gpuAddress(),
+            output_grd.gpuAddress(),
             output_grd.size());
     }else{
         ASSERT(false);

--- a/src/operations/radam/radam.h
+++ b/src/operations/radam/radam.h
@@ -70,18 +70,18 @@ inline void radam(SArray<float>& values,
         dim3 block(block_size);
         dim3 grid (std::ceil((float)values.size() / block_size));
         radam_kernel<<<grid, block>>>(
-            values          .gpu_address(),
-            gradients       .gpu_address(),
-            first_moment    .gpu_address(),
-            second_moment   .gpu_address(),
+            values          .gpuAddress(),
+            gradients       .gpuAddress(),
+            first_moment    .gpuAddress(),
+            second_moment   .gpuAddress(),
             values.size(),
             step, lr, beta1, beta2, eps, N_sma_threshold);
     } else {
         radam_host(
-            values          .cpu_address(),
-            gradients       .cpu_address(),
-            first_moment    .cpu_address(),
-            second_moment   .cpu_address(),
+            values          .cpuAddress(),
+            gradients       .cpuAddress(),
+            first_moment    .cpuAddress(),
+            second_moment   .cpuAddress(),
             values.size(),
             step, lr, beta1, beta2, eps, N_sma_threshold);
     }

--- a/src/operations/ranger/ranger.h
+++ b/src/operations/ranger/ranger.h
@@ -79,21 +79,21 @@ inline void ranger(SArray<float>& values,
         dim3 block(block_size);
         dim3 grid (std::ceil((float)values.size() / block_size));
         ranger_kernel<<<grid, block>>>(
-            values          .gpu_address(),
-            gradients       .gpu_address(),
-            first_moment    .gpu_address(),
-            second_moment   .gpu_address(),
-            slow_buffer     .gpu_address(),
+            values          .gpuAddress(),
+            gradients       .gpuAddress(),
+            first_moment    .gpuAddress(),
+            second_moment   .gpuAddress(),
+            slow_buffer     .gpuAddress(),
             values.size(),
             step, lr, beta1, beta2, eps, 
             alpha, k, N_sma_threshold);
     } else {
         ranger_host(
-            values          .cpu_address(),
-            gradients       .cpu_address(),
-            first_moment    .cpu_address(),
-            second_moment   .cpu_address(),
-            slow_buffer     .cpu_address(),
+            values          .cpuAddress(),
+            gradients       .cpuAddress(),
+            first_moment    .cpuAddress(),
+            second_moment   .cpuAddress(),
+            slow_buffer     .cpuAddress(),
             values.size(),
             step, lr, beta1, beta2, eps, 
             alpha, k, N_sma_threshold);

--- a/src/operations/relu/relu.h
+++ b/src/operations/relu/relu.h
@@ -43,20 +43,20 @@ inline void relu   (const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         relu_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
             A.size());
     }else{
         relu_host(
-            A.cpu_address(),
-            B.cpu_address(),
+            A.cpuAddress(),
+            B.cpuAddress(),
             A.size());
     }
 }

--- a/src/operations/relu_bp/relu_bp.h
+++ b/src/operations/relu_bp/relu_bp.h
@@ -49,24 +49,24 @@ inline void relu_bp   (const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         relu_bp_kernel<<<grid, block>>>(
-            A    .gpu_address(),
-            A_grd.gpu_address(),
-            B    .gpu_address(),
-            B_grd.gpu_address(),
+            A    .gpuAddress(),
+            A_grd.gpuAddress(),
+            B    .gpuAddress(),
+            B_grd.gpuAddress(),
             A.size());
     }else{
         relu_bp_host(
-            A    .cpu_address(),
-            A_grd.cpu_address(),
-            B    .cpu_address(),
-            B_grd.cpu_address(),
+            A    .cpuAddress(),
+            A_grd.cpuAddress(),
+            B    .cpuAddress(),
+            B_grd.cpuAddress(),
             A.size());
     }
 }

--- a/src/operations/sigmoid/sigmoid.h
+++ b/src/operations/sigmoid/sigmoid.h
@@ -46,21 +46,21 @@ inline void sigmoid   (const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         sigmoid_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
             A.size(),
             scalar);
     }else{
         sigmoid_host(
-            A.cpu_address(),
-            B.cpu_address(),
+            A.cpuAddress(),
+            B.cpuAddress(),
             A.size(),
             scalar);
     }

--- a/src/operations/sigmoid_bp/sigmoid_bp.h
+++ b/src/operations/sigmoid_bp/sigmoid_bp.h
@@ -52,25 +52,25 @@ inline void sigmoid_bp(const SArray<float> &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size = 1024;
         dim3 block(block_size);
         dim3 grid (std::ceil((float)A.size() / block_size));
         sigmoid_bp_kernel<<<grid, block>>>(
-            A    .gpu_address(),
-            A_grd.gpu_address(),
-            B    .gpu_address(),
-            B_grd.gpu_address(),
+            A    .gpuAddress(),
+            A_grd.gpuAddress(),
+            B    .gpuAddress(),
+            B_grd.gpuAddress(),
             A.size(),
             scalar);
     }else{
         sigmoid_bp_host(
-            A    .cpu_address(),
-            A_grd.cpu_address(),
-            B    .cpu_address(),
-            B_grd.cpu_address(),
+            A    .cpuAddress(),
+            A_grd.cpuAddress(),
+            B    .cpuAddress(),
+            B_grd.cpuAddress(),
             A.size(),
             scalar);
     }

--- a/src/operations/softmax/softmax.h
+++ b/src/operations/softmax/softmax.h
@@ -30,22 +30,22 @@ inline void softmax   (const DenseMatrix &A,
 
     if(mode == DEVICE){
 
-        ASSERT(A.gpu_address());
-        ASSERT(B.gpu_address());
+        ASSERT(A.gpuAddress());
+        ASSERT(B.gpuAddress());
 
         constexpr int block_size_m = 1;
         constexpr int block_size_n = 1024;
         dim3 block(block_size_n, block_size_m);
         dim3 grid (std::ceil((float)A.n / block_size_n),1);
         softmax_kernel<<<grid, block>>>(
-            A.gpu_address(),
-            B.gpu_address(),
+            A.gpuAddress(),
+            B.gpuAddress(),
             A.m,
             A.n);
     }else{
 //        softmax_host(
-//            A.cpu_address(),
-//            B.cpu_address(),
+//            A.cpuAddress(),
+//            B.cpuAddress(),
 //            A.m,
 //            A.n);
         ERROR(false);

--- a/src/operations/softmax_bp/softmax_bp.h
+++ b/src/operations/softmax_bp/softmax_bp.h
@@ -32,24 +32,24 @@ inline void softmax_bp(      DenseMatrix &A_grd,
 
     if(mode == DEVICE){
 
-        ASSERT(A_grd.gpu_address());
-        ASSERT(B.gpu_address());
-        ASSERT(B_grd.gpu_address());
+        ASSERT(A_grd.gpuAddress());
+        ASSERT(B.gpuAddress());
+        ASSERT(B_grd.gpuAddress());
 
         constexpr int block_size_m = 16;
         constexpr int block_size_n = 16;
         dim3 block(block_size_n, block_size_m);
         dim3 grid (std::ceil((float)A_grd.n / block_size_n),std::ceil((float)A_grd.m / block_size_m));
         softmax_bp_kernel<<<grid, block>>>(
-            A_grd.gpu_address(),
-            B.gpu_address(),
-            B_grd.gpu_address(),
+            A_grd.gpuAddress(),
+            B.gpuAddress(),
+            B_grd.gpuAddress(),
             A_grd.m,
             A_grd.n);
     }else{
 //        softmax_host(
-//            A.cpu_address(),
-//            B.cpu_address(),
+//            A.cpuAddress(),
+//            B.cpuAddress(),
 //            A.m,
 //            A.n);
         ERROR(false);

--- a/src/operations/sparse_affine/sparse_affine.h
+++ b/src/operations/sparse_affine/sparse_affine.h
@@ -75,10 +75,10 @@ inline void sparse_affine(
 
     if(mode == DEVICE){
 
-        ASSERT(mat.gpu_address())
-        ASSERT(inp.column_indices.gpu_address())
-        ASSERT(bia.gpu_address())
-        ASSERT(res.gpu_address())
+        ASSERT(mat.gpuAddress())
+        ASSERT(inp.column_indices.gpuAddress())
+        ASSERT(bia.gpuAddress())
+        ASSERT(res.gpuAddress())
 
         constexpr int block_size_x = 1;
         constexpr int block_size_y = 256;
@@ -88,11 +88,11 @@ inline void sparse_affine(
                    std::ceil((float)res.m / block_size_y));
 
         sparse_affine_kernel<<<grid, block>>>(
-            mat.gpu_address(),
-            inp.column_indices.gpu_address(),
+            mat.gpuAddress(),
+            inp.column_indices.gpuAddress(),
             inp.max_entries_per_column,
-            bia.gpu_address(),
-            res.gpu_address(),
+            bia.gpuAddress(),
+            res.gpuAddress(),
             M,B,
             mat.leading_dimension,
             res.leading_dimension);

--- a/src/operations/sparse_affine_bp/sparse_affine_bp.h
+++ b/src/operations/sparse_affine_bp/sparse_affine_bp.h
@@ -79,11 +79,11 @@ inline void sparse_affine_bp(
 
     if(mode == DEVICE){
 
-        ASSERT(mat_grd.gpu_address())
-        ASSERT(inp    .column_indices.gpu_address())
-        ASSERT(bia_grd.gpu_address())
-        ASSERT(res_grd.gpu_address())
-        ASSERT(res    .gpu_address())
+        ASSERT(mat_grd.gpuAddress())
+        ASSERT(inp    .column_indices.gpuAddress())
+        ASSERT(bia_grd.gpuAddress())
+        ASSERT(res_grd.gpuAddress())
+        ASSERT(res    .gpuAddress())
 
 //        mat_grd.clear<DEVICE>();
 //        bia_grd.clear<DEVICE>();
@@ -96,12 +96,12 @@ inline void sparse_affine_bp(
                    std::ceil((float)res_grd.m / block_size_y));
 
         sparse_affine_bp_kernel<<<grid, block>>>(
-            mat_grd.gpu_address(),
-            inp.column_indices.gpu_address(),
+            mat_grd.gpuAddress(),
+            inp.column_indices.gpuAddress(),
             inp.max_entries_per_column,
-            bia_grd.gpu_address(),
-            res.gpu_address(),
-            res_grd.gpu_address(),
+            bia_grd.gpuAddress(),
+            res.gpuAddress(),
+            res_grd.gpuAddress(),
             M,B,
             mat_grd.leading_dimension,
             res_grd.leading_dimension,

--- a/src/optimizer/Adam.h
+++ b/src/optimizer/Adam.h
@@ -41,8 +41,8 @@ struct Adam : Optimiser {
             // clang-format off
             first_moments .push_back(SArray<float> {t->values.size()});
             second_moments.push_back(SArray<float> {t->values.size()});
-            first_moments [first_moments.size() - 1].malloc_gpu();
-            second_moments[first_moments.size() - 1].malloc_gpu();
+            first_moments [first_moments.size() - 1].mallocGpu();
+            second_moments[first_moments.size() - 1].mallocGpu();
             // clang-format on
             value_ranges.push_back(
                 std::tuple<float, float> {t->min_allowed_value, t->max_allowed_value});

--- a/src/optimizer/AdamW.h
+++ b/src/optimizer/AdamW.h
@@ -44,8 +44,8 @@ struct AdamW : Optimiser {
             exp_avg   .push_back(SArray<float>{ t->values.size()});
             exp_avg_sq.push_back(SArray<float>{ t->values.size()});
 
-            exp_avg   [exp_avg.size()    - 1].malloc_gpu();
-            exp_avg_sq[exp_avg_sq.size() - 1].malloc_gpu();
+            exp_avg   [exp_avg.size()    - 1].mallocGpu();
+            exp_avg_sq[exp_avg_sq.size() - 1].mallocGpu();
             // clang-format on
             value_ranges.push_back(
                 std::tuple<float, float> {t->min_allowed_value, t->max_allowed_value});

--- a/src/optimizer/RAdam.h
+++ b/src/optimizer/RAdam.h
@@ -43,8 +43,8 @@ struct RAdam : Optimiser {
             exp_avg.push_back(SArray<float> {t->values.size()});
             exp_avg_sq.push_back(SArray<float> {t->values.size()});
 
-            exp_avg[exp_avg.size() - 1].malloc_gpu();
-            exp_avg_sq[exp_avg_sq.size() - 1].malloc_gpu();
+            exp_avg[exp_avg.size() - 1].mallocGpu();
+            exp_avg_sq[exp_avg_sq.size() - 1].mallocGpu();
 
             value_ranges.push_back(
                 std::tuple<float, float> {t->min_allowed_value, t->max_allowed_value});

--- a/src/optimizer/Ranger.h
+++ b/src/optimizer/Ranger.h
@@ -48,9 +48,9 @@ struct Ranger : Optimiser {
             exp_avg_sq .push_back(SArray<float>{ t->values.size()});
             slow_buffer.push_back(SArray<float>{ t->values.size()});
 
-            exp_avg    [exp_avg.size()     - 1].malloc_gpu();
-            exp_avg_sq [exp_avg_sq.size()  - 1].malloc_gpu();
-            slow_buffer[slow_buffer.size() - 1].malloc_gpu();
+            exp_avg    [exp_avg.size()     - 1].mallocGpu();
+            exp_avg_sq [exp_avg_sq.size()  - 1].mallocGpu();
+            slow_buffer[slow_buffer.size() - 1].mallocGpu();
             // clang-format on
 
             value_ranges.push_back(

--- a/src/trainer.h
+++ b/src/trainer.h
@@ -63,8 +63,8 @@ class Trainer {
         network->setLossFunction(this->loss_f);
         network->setBatchSize(BatchSize);
 
-        target_mask.malloc_cpu();
-        target_mask.malloc_gpu();
+        target_mask.mallocCpu();
+        target_mask.mallocGpu();
     }
 
     void fit(vector<string> files, vector<string> validation_files, string output) {
@@ -127,9 +127,9 @@ class Trainer {
             Arch::assign_inputs_batch(*ds, *network, target, target_mask);
             network->uploadInputs();
 
-            target.gpu_upload();
-            target_mask.gpu_upload();
-            loss_f->loss.gpu_download();
+            target.gpuUpload();
+            target_mask.gpuUpload();
+            loss_f->loss.gpuDownload();
 
             // measure time and print output
             timer->tock();
@@ -147,7 +147,7 @@ class Trainer {
 
             epoch_loss += loss_f->loss(0);
             loss_f->loss(0) = 0;
-            loss_f->loss.gpu_upload();
+            loss_f->loss.gpuUpload();
             network->batch(target,
                            target_mask);
             optim->apply(1);
@@ -159,7 +159,7 @@ class Trainer {
     float validate(DataSet* validation_data) {
         float prev_loss = loss_f->loss(0);
         loss_f->loss(0) = 0;
-        loss_f->loss.gpu_upload();
+        loss_f->loss.gpuUpload();
 
         float total_loss_sum = 0;
 
@@ -175,8 +175,8 @@ class Trainer {
             Arch::assign_inputs_batch(temp, *network, target, target_mask);
             network->uploadInputs();
 
-            target.gpu_upload();
-            target_mask.gpu_upload();
+            target.gpuUpload();
+            target_mask.gpuUpload();
 
             network->feed();
 
@@ -187,17 +187,17 @@ class Trainer {
                           DEVICE);
 
             // reset loss to avoid loss of accuracy
-            loss_f->loss.gpu_download();
+            loss_f->loss.gpuDownload();
             total_loss_sum += loss_f->loss.get(0);
             loss_f->loss.get(0) = 0;
-            loss_f->loss.gpu_upload();
+            loss_f->loss.gpuUpload();
         }
 
 
-        loss_f->loss.gpu_download();
+        loss_f->loss.gpuDownload();
 
         loss_f->loss(0)       = prev_loss;
-        loss_f->loss.gpu_upload();
+        loss_f->loss.gpuUpload();
 
         return total_loss_sum / c;
     }


### PR DESCRIPTION
The main branch for CudAD has been broken due to naming inconsistencies within the SArray file. This does replacements across the project to resolve all errors.

CudAD now compiles locally.
```
     Creating library C:/Programming/CudAD/cmake-build-release/Release/CudAD.lib and object C:/Programming/CudAD/cmake-build-release/Release/CudAD.exp
LINK : warning LNK4098: defaultlib 'LIBCMT' conflicts with use of other libs; use /NODEFAULTLIB:library [C:\Programming\CudAD\cmake-build-release\CudAD.vcxproj]
  CudAD.vcxproj -> C:\Programming\CudAD\cmake-build-release\Release\CudAD.exe
```